### PR TITLE
chore(ci): add Copilot custom review instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,4 +21,4 @@
 - This is a school project (DevSecOps course) using TypeScript, Express 5, SQLite
 - We use Biome for linting/formatting - do not suggest ESLint/Prettier rules
 - Swedish comments are intentional and part of our code style
-- Seed data with test credentials is expected in development mode
+- Seed data with test credentials in development-only code paths is expected; flag hardcoded credentials anywhere else


### PR DESCRIPTION
Copilot-instruktioner för code review

Lägger till .github/copilot-instructions.md som styr Copilots code review för hela teamet.
Fokus på säkerhet och logikfel, ignorerar stavfel i svenska kommentarer.
Vad jag har läst mig till så fungerar dessa instruktioner även för copilot reviews lokalt, eftersom de ligger i repot och synkas till dig vid 'pull'. 