### PR TITLE
Uppdatera README och återställ .env i gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
-# Environment variables (secrets!)
+# Environment variables (secrets!) - ALDRIG committa .env-filer!
+# Använd .env.example som mall (committas), .env för lokala secrets (ignoreras)
+.env
 .env.local
 .env.*.local
+api/.env
+app/.env
 
 # SQLite database files
 *.db

--- a/README.md
+++ b/README.md
@@ -1,26 +1,52 @@
-# Introduktion
+# Joinly
 
-**Joinly** - är en app för att hitta sällskap för träning – snabbt och utan krångel.
+**Joinly** - en app för att hitta sällskap för träning, snabbt och utan krångel.
 Här kan du enkelt hitta eller skapa aktiviteter som löpning, cykling eller motorcykelturer i närheten av dig.
-Du behöver inte gå med i grupper eller planera långt i förväg – se vad som händer idag eller imorgon och häng på.
+Du behöver inte gå med i grupper eller planera långt i förväg - se vad som händer idag eller imorgon och häng på.
 
-Denna lösning är byggd i **NodeJS** (Backend), **Vite, React** och **TypeScript** (Frontend).
+## Teknikstack
 
-# Komma igång
+| Del | Teknologi |
+|-----|-----------|
+| Backend | Node.js 22 / Express 5 / TypeScript |
+| Databas | SQLite (better-sqlite3) |
+| Autentisering | JWT (jsonwebtoken + bcrypt) |
+| Frontend | Vite + React 19 + TypeScript |
+| UI-bibliotek | Material UI (MUI) |
+| Routing | TanStack Router (filbaserad) |
+| Linting | Biome (backend + frontend) |
+| Tester | Newman (API-integration), Vitest (unit) |
+| CI/CD | GitHub Actions |
+
+## Komma igång
 
 Följ stegen nedan för att få igång projektet på din lokala maskin.
 
-## Installation frontend
+### 1. Klona repot
 
 ```bash
-cd app
-npm install
-npm run dev
+git clone <repo-url>
+cd joinly
 ```
 
-Frontend körs på http://localhost:3000
+### 2. Konfigurera miljövariabler (backend)
 
-## Installation backend (API)
+Backend kräver en `.env`-fil med hemliga variabler. En mall finns i `api/.env.example`.
+
+```bash
+cp api/.env.example api/.env
+```
+
+Öppna `api/.env` och fyll i värden:
+
+- **JWT_SECRET** - Ändras till en kryptografiskt slumpmässig nyckel (minst 44 tecken, t.ex. `openssl rand -base64 32`)
+- **SEED_TESTUSER_1_PASSWORD** m.fl. - Lösenord för seed-användare (krav: 8+ tecken, stor bokstav, liten bokstav, siffra, specialtecken)
+- **RATE_LIMIT_ENABLED** - `false` för lokal utveckling, `true` i produktion
+- **ACL_ENABLED** - `true` (default). Stäng **aldrig** av i produktion. Vid lokal felsökning kan `false` användas tillfälligt - säkerställ att det återställs innan push
+
+> `.env`-filer är gitignored och ska **aldrig** committas. Använd `.env.example` som referens.
+
+### 3. Installera och starta backend
 
 ```bash
 cd api
@@ -30,24 +56,71 @@ npm run dev
 
 API:et körs på http://localhost:3001
 
-Se [api/README.md](api/README.md) för mer info om backend.
+Se [api/README.md](api/README.md) för detaljerad API-dokumentation.
 
-# Git
+### 4. Installera och starta frontend
 
-Vi har endast en `main`-branch. Utveckling sker i PR-brancher mot `main`.
+```bash
+cd app
+npm install
+npm run dev
+```
 
-# Inlämningsuppgift
+Frontend körs på http://localhost:3000
+
+> Starta backend först - frontend anropar API:et på port 3001.
+
+## Funktionalitet
+
+- **Registrering och inloggning** - JWT-baserad autentisering
+- **Events** - Skapa, visa och hantera aktiviteter
+- **Eventanmälan** - Anmäl/avanmäl dig till events
+- **Rollbaserad åtkomstkontroll (ACL)** - Middleware som styr behörigheter per endpoint
+- **Skyddade routes** - Frontend omdirigerar till login vid utgången session
+
+## Testning
+
+```bash
+# Unit-tester (Vitest)
+cd api && npm test
+
+# API-integrationstester (Newman)
+# Kräver att backend körs (npm run dev i api/)
+cd api && npm run test:api
+
+# Lint (Biome)
+cd api && npm run lint
+cd app && npm run lint
+```
+
+## CI/CD
+
+GitHub Actions kör automatiskt vid push och PR:
+
+- Lint (Biome)
+- Build (TypeScript-kompilering + Vite)
+- Säkerhetsgranskning (npm audit)
+- API-integrationstester (Newman)
+
+Branch protection är aktiverad på `main` - alla ändringar går via PR.
+
+## Git-workflow
+
+Utveckling sker i feature-brancher som mergas till `main` via pull requests.
+Branch protection kräver godkänd review och att CI passerar.
+
+## Inlämningsuppgift
 
 Detta är en inlämningsuppgift inom kursen "[DevSecOps med säkerhetsinriktning](https://www.nbi-handelsakademin.se/utbildningar/it-tech/devsecops-med-sakerhetsinriktning/)" på NBI-Handelsakademin.
 
-## Inledning
+### Inledning
 I denna projektuppgift ska ni i grupp planera, utveckla, integrera och lansera en social webbapplikation med fokus på kontinuerlig utveckling, automation och säker drift i molnmiljö. Projektet genomförs parallellt med kursens undervisningsmoment och utgör kursens examinerande del.
 
 Arbetet ska genomföras med ett DevSecOps-orienterat arbetssätt, där utveckling, testning och säkerhet ses som en sammanhängande helhet snarare än separata faser.
 
 I praktiken ska alla moment representeras i kod som automatiseras som kontinuerlig integration i en produkt.
 
-## Bakgrundsbeskrivning
+### Bakgrundsbeskrivning
 Moderna webbaserade och sociala applikationer utvecklas i miljöer där kraven på förändringstakt, stabilitet och säkerhet är höga. För att möta dessa krav används idag arbetssätt där:
 
 - funktionalitet utvecklas och integreras löpande
@@ -56,4 +129,4 @@ Moderna webbaserade och sociala applikationer utvecklas i miljöer där kraven p
 - säkerhet och integritet hanteras tidigt i processen
 - Projektuppgiften är utformad för att ge er praktisk erfarenhet av dessa principer, med särskilt fokus på CI och säker systemutveckling.
 
-Läs mer om uppgiften på [här](https://dsoht25d-hak.lms.nodehill.se/article/projektuppgift-devsevops-kultur-processer-och-automation).
+Läs mer om uppgiften [här](https://dsoht25d-hak.lms.nodehill.se/article/projektuppgift-devsevops-kultur-processer-och-automation).


### PR DESCRIPTION
## Sammanfattning
Uppdaterar root README.md med aktuell projektinfo och återställer .env-regler i .gitignore.

## Ändringar
- **README.md**: Teknikstack-tabell, miljövariabel-setup (med `openssl rand`-instruktion), funktionalitetsöversikt, testning, CI/CD, git-workflow
- **.gitignore**: Återställt .env-ignorering med tydliga kommentarer (`.env`, `api/.env`, `app/.env`)

## Testat lokalt
- [x] Inga secrets i ändrade filer (security audit)
- [x] Copilot Code Review - 3 kommentarer, 2 åtgärdade
- [x] Markdown renderas korrekt

Closes #