### PR TITLE
docs(api): uppdatera dokumentation med korrekta siffror och saknade endpoints

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -231,7 +231,7 @@ Se [docs/security.md](docs/security.md) för produktionskrav och säkerhetskontr
 
 ### 2026-02-15 - ACL-middleware (Pål) - Epic #62, Issue #63
 
-- Implementerat databasdriven ACL med 24 regler i `acl`-tabellen
+- Implementerat databasdriven ACL med 21 regler i `acl`-tabellen
 - ACL-middleware ersätter alla hårdkodade behörighetskontroller
 - `optionalToken` ersätter `authenticateToken` - extraherar JWT utan att blockera
 - Ägarskapsverifiering via `fieldMatchingUserId` (skapare eller admin)

--- a/api/README.md
+++ b/api/README.md
@@ -128,6 +128,7 @@ api/
 │   │   ├── database-users.ts        # Users-tabell & seed-data
 │   │   ├── database-events.ts       # Events-tabell & seed-data
 │   │   ├── database-registrations.ts # Event-registreringar
+│   │   ├── database-chat.ts          # Chattmeddelanden
 │   │   ├── database-acl.ts          # ACL-regler (seed-data)
 │   │   └── database-blacklist.ts    # Token blacklist (logout)
 │   ├── middleware/
@@ -135,7 +136,8 @@ api/
 │   │   └── acl.ts              # Rollbaserad åtkomstkontroll
 │   ├── routes/
 │   │   ├── auth.ts             # Register, login, logout & me
-│   │   ├── events.ts           # Events CRUD + filter
+│   │   ├── events.ts           # Events CRUD + filter + chat
+│   │   ├── myevents.ts         # Mina events (anmälda + skapade)
 │   │   └── registrations.ts    # Anmälan/avanmälan till events
 │   └── utils/
 │       └── validators.ts       # Input-validering
@@ -221,15 +223,15 @@ Se [docs/security.md](docs/security.md) för produktionskrav och säkerhetskontr
 ### 2026-03-02 - CI-fix, SQL injection-tester och dokumentation (Pål)
 
 - Återställt `api-ci.yml` - API CI-pipeline var trasig sedan workflow-uppdelningen (frontend-kod hade kopierats in)
-- Lagt till SQL injection-testsvit (11 tester, 39 assertions) som verifierar defense in depth
+- Lagt till SQL injection-testsvit (11 tester, 40 assertions) som verifierar defense in depth
 - Lagt till saknad ACL-regel för `GET /api/myevents/created` (23→24 regler)
 - Fixat myevents-tester (felaktiga assertions)
-- Uppdaterat `test:api` att köra alla 8 Newman-samlingar (92 requests, 208 assertions totalt)
+- Uppdaterat `test:api` att köra alla 8 Newman-samlingar (104 requests, 208 assertions totalt)
 - Uppdaterat säkerhetsdokumentation med SQL injection-skydd och testresultat
 
 ### 2026-02-15 - ACL-middleware (Pål) - Epic #62, Issue #63
 
-- Implementerat databasdriven ACL med 21 regler i `acl`-tabellen
+- Implementerat databasdriven ACL med 24 regler i `acl`-tabellen
 - ACL-middleware ersätter alla hårdkodade behörighetskontroller
 - `optionalToken` ersätter `authenticateToken` - extraherar JWT utan att blockera
 - Ägarskapsverifiering via `fieldMatchingUserId` (skapare eller admin)

--- a/api/docs/api-guide.md
+++ b/api/docs/api-guide.md
@@ -73,7 +73,7 @@ Content-Type: application/json
   "message": "Användare skapad. Du kan nu logga in.",
   "token": "eyJhbGciOiJIUzI1NiIs...",
   "user": {
-    "id": 3,
+    "id": "b7f5c2e0-1a2b-4c3d-9e8f-123456789abc",
     "email": "anna@example.com",
     "name": "Anna Svensson",
     "role": "user"
@@ -110,7 +110,7 @@ Content-Type: application/json
   "message": "Inloggning lyckades.",
   "token": "eyJhbGciOiJIUzI1NiIs...",
   "user": {
-    "id": 3,
+    "id": "b7f5c2e0-1a2b-4c3d-9e8f-123456789abc",
     "email": "anna@example.com",
     "name": "Anna Svensson",
     "role": "user"
@@ -152,7 +152,7 @@ Authorization: Bearer <token>
 **Svar (200):**
 ```json
 {
-  "user": { "id": 3, "email": "anna@example.com", "role": "user" },
+  "user": { "id": "b7f5c2e0-1a2b-4c3d-9e8f-123456789abc", "email": "anna@example.com", "role": "user" },
   "message": "Användare är inloggad."
 }
 ```
@@ -403,3 +403,113 @@ Authorization: Bearer <token>
 | 400 | Ogiltigt event-ID |
 | 401 | Saknar eller ogiltig token |
 | 404 | Eventet finns inte eller du är inte anmäld |
+
+### Hämta mina event-anmälningar
+
+```http
+GET /api/myevents
+Authorization: Bearer <token>
+```
+
+**Svar (200):**
+```json
+{
+  "success": true,
+  "events": [
+    {
+      "id": "abc-123",
+      "title": "Lördagskonsert i parken",
+      "category": "music",
+      "start_time": "2026-03-15T18:00:00Z",
+      "city": "Stockholm",
+      "registered_at": "2026-03-01T12:00:00Z"
+    }
+  ],
+  "count": 1
+}
+```
+
+### Hämta events jag skapat
+
+```http
+GET /api/myevents/created
+Authorization: Bearer <token>
+```
+
+**Svar (200):**
+```json
+{
+  "success": true,
+  "events": [
+    {
+      "id": "abc-456",
+      "title": "Morgonlöpning Södermalm",
+      "category": "Running",
+      "start_time": "2026-03-20T07:00:00Z",
+      "city": "Stockholm"
+    }
+  ],
+  "count": 1
+}
+```
+
+### Hämta chattmeddelanden för event
+
+```http
+GET /api/events/:id/chat
+Authorization: Bearer <token>
+```
+
+**Svar (200):**
+```json
+{
+  "success": true,
+  "messages": [
+    {
+      "id": "msg-001",
+      "event_id": "abc-123",
+      "user_id": "b7f5c2e0-1a2b-4c3d-9e8f-123456789abc",
+      "message": "Vad roligt detta ska bli!",
+      "created_at": "2026-03-10T14:30:00Z"
+    }
+  ],
+  "count": 1
+}
+```
+
+**Fel:** 401 om token saknas/ogiltig, 404 om eventet inte finns.
+
+### Skicka chattmeddelande i event
+
+```http
+POST /api/events/:id/chat
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "message": "Jag kommer! Ses där!"
+}
+```
+
+**Svar (201):**
+```json
+{
+  "success": true,
+  "message": "Meddelande skapat framgångsrikt.",
+  "chatMessage": {
+    "id": "msg-002",
+    "event_id": "abc-123",
+    "user_id": "b7f5c2e0-1a2b-4c3d-9e8f-123456789abc",
+    "message": "Jag kommer! Ses där!",
+    "created_at": "2026-03-10T15:00:00Z"
+  }
+}
+```
+
+**Vanliga fel:**
+
+| Status | Orsak |
+|--------|-------|
+| 400 | Tomt meddelande |
+| 401 | Saknar eller ogiltig token |
+| 404 | Eventet finns inte |

--- a/api/docs/api-guide.md
+++ b/api/docs/api-guide.md
@@ -421,8 +421,7 @@ Authorization: Bearer <token>
       "title": "Lördagskonsert i parken",
       "category": "music",
       "start_time": "2026-03-15T18:00:00Z",
-      "city": "Stockholm",
-      "registered_at": "2026-03-01T12:00:00Z"
+      "city": "Stockholm"
     }
   ],
   "count": 1
@@ -477,7 +476,7 @@ Authorization: Bearer <token>
 }
 ```
 
-**Fel:** 401 om token saknas/ogiltig, 404 om eventet inte finns.
+**Fel:** 401 om token saknas/ogiltig, 403 om användaren inte är registrerad på eventet, 404 om eventet inte finns.
 
 ### Skicka chattmeddelande i event
 
@@ -512,4 +511,5 @@ Content-Type: application/json
 |--------|-------|
 | 400 | Tomt meddelande |
 | 401 | Saknar eller ogiltig token |
+| 403 | Inte registrerad på eventet |
 | 404 | Eventet finns inte |

--- a/api/docs/database.md
+++ b/api/docs/database.md
@@ -80,7 +80,7 @@ Utgångna tokens rensas automatiskt vid serverstart via `cleanExpiredTokens()`.
 
 ### acl
 
-Regler för rollbaserad åtkomstkontroll (Access Control List). 21 seed-regler.
+Regler för rollbaserad åtkomstkontroll (Access Control List). 24 seed-regler.
 
 | Fält | Typ | Begränsning | Beskrivning |
 |------|-----|-------------|-------------|
@@ -95,6 +95,24 @@ Se [security.md](security.md) för detaljer om hur ACL fungerar.
 
 **Källfil:** `src/db/database-acl.ts`
 
+### chat_messages
+
+Chattmeddelanden inom events. Varje meddelande tillhör ett event och en användare.
+
+| Fält | Typ | Begränsning | Beskrivning |
+|------|-----|-------------|-------------|
+| `id` | TEXT | PRIMARY KEY | UUID (genereras med `uuidv4()`) |
+| `event_id` | TEXT | NOT NULL, FK → events(id) | Eventet meddelandet tillhör |
+| `user_id` | TEXT | NOT NULL, FK → users(id) | Användaren som skrev meddelandet |
+| `message` | TEXT | NOT NULL | Meddelandetext |
+| `created_at` | DATETIME | DEFAULT CURRENT_TIMESTAMP | Tidpunkt |
+
+**Constraints:**
+- `FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE CASCADE`
+- `FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE`
+
+**Källfil:** `src/db/database-chat.ts`
+
 ---
 
 ## Relationer
@@ -104,9 +122,13 @@ users
   │
   ├──< events              (creator_user_id → users.id)
   │      │
-  │      └──< event_registrations  (event_id → events.id, CASCADE)
+  │      ├──< event_registrations  (event_id → events.id, CASCADE)
+  │      │
+  │      └──< chat_messages        (event_id → events.id, CASCADE)
   │
-  └──< event_registrations        (user_id → users.id, CASCADE)
+  ├──< event_registrations        (user_id → users.id, CASCADE)
+  │
+  └──< chat_messages               (user_id → users.id, CASCADE)
 
 
 token_blacklist              (fristående, ingen FK)
@@ -114,11 +136,11 @@ acl                          (konfigurationstabell, ingen FK)
 ```
 
 **Cascade-beteende:**
-- Tar man bort en user → alla dennes event_registrations tas bort automatiskt
-- Tar man bort ett event → alla registreringar till det eventet tas bort automatiskt
+- Tar man bort en user → alla dennes event_registrations och chat_messages tas bort automatiskt
+- Tar man bort ett event → alla registreringar och chattmeddelanden till det eventet tas bort automatiskt
 
 **ID-strategi:**
-- `users` och `events` använder UUID (TEXT) - svårare att gissa, bättre för distribuerade system
+- `users`, `events` och `chat_messages` använder UUID (TEXT) - svårare att gissa, bättre för distribuerade system
 - Stödtabeller (`event_registrations`, `token_blacklist`, `acl`) använder INTEGER AUTOINCREMENT - effektivare indexering
 
 ---
@@ -143,9 +165,13 @@ Seed-data skapas bara i development (`NODE_ENV !== 'production'`). Om tabellen r
 
 - test@example.com registreras automatiskt till första eventet (ID:n hämtas dynamiskt)
 
+### Chattmeddelanden
+
+- Ett seed-meddelande per registrerad deltagare i första eventet
+
 ### ACL-regler
 
-21 regler som täcker alla endpoints. Se [security.md](security.md) för komplett lista.
+24 regler som täcker alla endpoints. Se [security.md](security.md) för komplett lista.
 
 ---
 

--- a/api/docs/ny-endpoint-guide.md
+++ b/api/docs/ny-endpoint-guide.md
@@ -644,8 +644,8 @@ npm run dev
 ```
 
 ### 2. Testa endpoints manuellt
-- API: `http://localhost:3000/api/notifications`
-- Swagger UI: `http://localhost:3000/swagger`
+- API: `http://localhost:3001/api/notifications`
+- Swagger UI: `http://localhost:3001/swagger`
 
 ### 3. Generera OpenAPI-specifikation
 ```bash
@@ -669,7 +669,7 @@ Detta skapar:
     "variable": [
         {
             "key": "baseUrl",
-            "value": "http://localhost:3000"
+            "value": "http://localhost:3001"
         }
     ],
     "item": [


### PR DESCRIPTION
## Sammanfattning
Uppdaterar API-dokumentationen så att den stämmer med faktisk kod och aktuella testsiffror.

## Ändringar

### database.md
- Ny tabell `chat_messages` dokumenterad (saknades helt)
- ACL-regelantal korrigerat: 21→24 (två ställen)
- Relationsdiagram uppdaterat med chat_messages
- Cascade-beskrivning uppdaterad
- Seed-data: chattmeddelanden tillagda
- ID-strategi: chat_messages tillagd bland UUID-tabeller

### api-guide.md
- Saknade endpoints tillagda: myevents, myevents/created, chat GET/POST
- User ID fixat från integer (3) till UUID i alla JSON-exempel

### README.md
- Projektstruktur: database-chat.ts och myevents.ts tillagda
- Ändringslogg: 39→40 assertions, 92→104 requests, 21→24 ACL-regler

### ny-endpoint-guide.md
- Port fixad: 3000→3001

## Testat lokalt
- [x] Alla siffror verifierade mot faktisk kod och testsamlingar
- [x] Inga kodändringar, bara dokumentation