### PR TITLE
fix(security): hide Swagger in production

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -28,6 +28,11 @@ ACL_ENABLED=true
 # I produktion: RATE_LIMIT_ENABLED=true
 RATE_LIMIT_ENABLED=false
 
+# Swagger UI
+# Standard är AV (säkert default i produktion).
+# Sätt true lokalt och i staging. Sätt aldrig true i produktion.
+SWAGGER_ENABLED=false
+
 # Loggning
 # LOG_PRETTY=true ger färgad, läsbar terminal-output (kräver pino-pretty i devDependencies)
 # Sätt aldrig true i produktion - där vill vi ren JSON för log-aggregatorer

--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -16,6 +16,9 @@ interface Config {
 	rateLimit: {
 		enabled: boolean
 	}
+	swagger: {
+		enabled: boolean
+	}
 	isProduction: () => boolean
 	isDevelopment: () => boolean
 	isTest: () => boolean
@@ -37,6 +40,9 @@ export const config: Config = {
 	},
 	rateLimit: {
 		enabled: process.env.RATE_LIMIT_ENABLED !== "false",
+	},
+	swagger: {
+		enabled: process.env.SWAGGER_ENABLED === "true",
 	},
 
 	// Hjälpfunktioner

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -100,7 +100,9 @@ app.use("/api/auth", authRoutes)
 app.use("/api/events", eventRoutes)
 app.use("/api/events", registrationRoutes)
 app.use("/api/myevents", myEventsRoutes)
-app.use("/swagger", swaggerUi.serve, swaggerUi.setup(openApiSpec))
+if (process.env.SWAGGER_ENABLED === "true") {
+	app.use("/swagger", swaggerUi.serve, swaggerUi.setup(openApiSpec))
+}
 
 // Health endpoint - användbart för CI/CD och monitoring
 app.get("/api/health", (_req, res) => {
@@ -141,5 +143,9 @@ app.listen(PORT, () => {
 	console.log(`Joinly API körs på http://localhost:${PORT}`)
 	console.log(`Environment: ${config.server.nodeEnv}`)
 	console.log(`Health check: http://localhost:${PORT}/api/health`)
-	console.log(`Swagger docs: http://localhost:${PORT}/swagger`)
+	if (process.env.SWAGGER_ENABLED === "true") {
+		console.log(`Swagger docs: http://localhost:${PORT}/swagger`)
+	} else {
+		console.log("Swagger: avstängt (SWAGGER_ENABLED != true)")
+	}
 })

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -100,7 +100,7 @@ app.use("/api/auth", authRoutes)
 app.use("/api/events", eventRoutes)
 app.use("/api/events", registrationRoutes)
 app.use("/api/myevents", myEventsRoutes)
-if (process.env.SWAGGER_ENABLED === "true") {
+if (config.swagger.enabled) {
 	app.use("/swagger", swaggerUi.serve, swaggerUi.setup(openApiSpec))
 }
 
@@ -143,7 +143,7 @@ app.listen(PORT, () => {
 	console.log(`Joinly API körs på http://localhost:${PORT}`)
 	console.log(`Environment: ${config.server.nodeEnv}`)
 	console.log(`Health check: http://localhost:${PORT}/api/health`)
-	if (process.env.SWAGGER_ENABLED === "true") {
+	if (config.swagger.enabled) {
 		console.log(`Swagger docs: http://localhost:${PORT}/swagger`)
 	} else {
 		console.log("Swagger: avstängt (SWAGGER_ENABLED != true)")

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -115,8 +115,9 @@ app.get("/api/health", (_req, res) => {
 
 app.get("/", (_req, res) => {
 	res.json({
-		message:
-			"Välkommen till Joinly API! Se swagger-dokumentationen på /swagger",
+		message: config.swagger.enabled
+			? "Välkommen till Joinly API! Se swagger-dokumentationen på /swagger"
+			: "Välkommen till Joinly API!",
 	})
 })
 
@@ -144,6 +145,11 @@ app.listen(PORT, () => {
 	console.log(`Environment: ${config.server.nodeEnv}`)
 	console.log(`Health check: http://localhost:${PORT}/api/health`)
 	if (config.swagger.enabled) {
+		if (config.isProduction()) {
+			console.warn(
+				"VARNING: Swagger är aktiverat i produktion. Inaktivera i prod."
+			)
+		}
 		console.log(`Swagger docs: http://localhost:${PORT}/swagger`)
 	} else {
 		console.log("Swagger: avstängt (SWAGGER_ENABLED != true)")


### PR DESCRIPTION
## Sammanfattning

Åtgärdar **STRIDE I1** — Swagger publikt exponerat. `/swagger`-routen registrerades tidigare alltid, vilket exponerade hela API-strukturen utan inloggning.

## Ändringar

- `/swagger` registreras nu bara om `SWAGGER_ENABLED=true` är satt
- Default är AV — ingen env-var satt betyder att Swagger är dolt
- Startup-loggen bekräftar tydligt om Swagger är på eller av
- `.env.example` dokumenterar den nya variabeln
- Root `/`-endpointen visar inte Swagger-länk när Swagger är avstängt
- Startup-loggen varnar tydligt om Swagger av misstag är aktiverat i produktion

## Hur det används

- **Lokalt:** sätt `SWAGGER_ENABLED=true` i `.env`
- **Produktion (Docker/Railway/Vercel):** sätt ingenting — Swagger dolt per default

## Testat

- [x] `SWAGGER_ENABLED=true` → `/swagger` svarar 301/200
- [x] `SWAGGER_ENABLED=false` → `/swagger` svarar 404
- [x] Ingen env-var satt → `/swagger` svarar 404
- [x] Root `/` visar inte Swagger-länk när Swagger är avstängt
- [x] npm run lint — inga fel
- [x] Newman 8 samlingar — 92 requests, 207 assertions, 0 fel