### PR TITLE
feat(api): rate limiting på write-endpoints (STRIDE D1)

### DIFF
--- a/api/docs/security.md
+++ b/api/docs/security.md
@@ -127,16 +127,79 @@ Detta ger säkrare sessionshantering, speciellt viktigt om en token komprometter
 
 ## Rate Limiting
 
-Auth-endpoints skyddas mot brute-force:
+Alla write-endpoints och auth-endpoints skyddas mot överbelastning och brute-force.
 
-| Endpoint | Gräns per IP | Gräns per email | Fönster |
-|----------|-------------|-----------------|---------|
-| `/api/auth/register` | 5 req | - | 15 min |
-| `/api/auth/login` | 10 req | 5 req | 15 min |
+### Auth-endpoints (brute-force-skydd)
 
-Login har dubbel rate limiting (IP + email) för att skydda mot distribuerade attacker.
+| Endpoint | Gräns | Fönster | Nyckel |
+|----------|-------|---------|--------|
+| `POST /api/auth/register` | 5 req | 15 min | Per IP |
+| `POST /api/auth/login` | 10 req | 15 min | Per IP |
+| `POST /api/auth/login` | 5 req | 15 min | Per e-postadress |
 
-Rate limiting kan stängas av med `RATE_LIMIT_ENABLED=false` i `.env` (för testning/CI).
+Login har dubbel rate limiting (IP + e-post) för att skydda mot distribuerade attacker mot ett specifikt konto.
+
+### Write-endpoints (DoS-skydd, kurs 3)
+
+| Endpoint | Gräns | Fönster | Nyckel |
+|----------|-------|---------|--------|
+| `POST /api/events` | 10 req | 15 min | Per IP |
+| `PUT /api/events/:id` | 20 req | 15 min | Per IP |
+| `DELETE /api/events/:id` | 10 req | 15 min | Per IP |
+| `POST /api/events/:id/chat` | 60 req | 1 min | Per IP |
+| `POST /api/events/:eventId/register` | 20 req | 15 min | Per IP |
+| `DELETE /api/events/:eventId/register` | 20 req | 15 min | Per IP |
+
+Chat-gränsen (60/min) motsvarar 1 meddelande per sekund — över normal mänsklig skrivhastighet men långt under vad ett skript genererar.
+
+### Implementation
+
+Rate limiters definieras i `src/utils/rate-limiters.ts` och appliceras direkt på respektive route. `app.set("trust proxy", 1)` är konfigurerat så att `req.ip` returnerar klientens riktiga IP-adress bakom Railway:s reverse proxy.
+
+Rate limiting kan stängas av med `RATE_LIMIT_ENABLED=false` i `.env` (för CI/Newman-tester).
+
+---
+
+## Swagger / API-dokumentation
+
+Swagger UI exponerar hela API-strukturen (alla routes, metoder, scheman och admin-endpoints). En angripare kan kartlägga hela attackytan utan att ha ett konto.
+
+Swagger styrs med miljövariabeln `SWAGGER_ENABLED`:
+
+```
+SWAGGER_ENABLED=false   # default — Swagger dolt i produktion
+SWAGGER_ENABLED=true    # aktivera t.ex. i utvecklingsmiljö
+```
+
+Implementationen i `src/index.ts`:
+
+```typescript
+if (config.swagger.enabled) {
+  app.use("/swagger", swaggerUi.serve, swaggerUi.setup(swaggerDocument))
+}
+```
+
+Swagger är **alltid dolt i produktion** om inte `SWAGGER_ENABLED=true` sätts explicit. Åtgärdar STRIDE I1.
+
+---
+
+## Loggning (Pino)
+
+API:et använder **Pino** för strukturerad JSON-loggning. Alla loggrader är maskinläsbara och inkluderar tidsstämpel, nivå och kontext.
+
+### Vad som loggas
+
+| Händelse | Lognivå | Inkluderar |
+|----------|---------|------------|
+| Lyckad inloggning | `info` | `userId`, `ip` |
+| Misslyckad inloggning | `warn` | `email` (ej lösenord), `ip` |
+| ACL-avslag (403/401) | `warn` | `route`, `method`, `userId` eller `"anonymous"` |
+| Serverfel (5xx) | `error` | Stack trace |
+| Serverstartup | `info` | Miljö, rate limiting-status, Swagger-status |
+
+### Varför Pino
+
+`console.log` försvinner vid omstart eller redeploy. Med Pino skrivs loggarna till stdout i JSON-format, vilket Railway och andra plattformar fångar och sparar. Det gör det möjligt att utreda incidenter i efterhand. Åtgärdar STRIDE R1.
 
 ---
 
@@ -155,7 +218,9 @@ Följande **måste** vara korrekt konfigurerat i produktion:
 | `JWT_SECRET` bytt från default | Servern vägrar starta med default-värdet |
 | `ACL_ENABLED=true` | Utan ACL kan alla nå alla endpoints |
 | `RATE_LIMIT_ENABLED=true` | Utan rate limiting är brute-force möjlig |
+| `SWAGGER_ENABLED` ej satt (default false) | Swagger exponerar hela API-strukturen publikt |
 | `NODE_ENV=production` | Styr seed-data, felmeddelanden m.m. |
+| Pino stdout fångad av plattformen | Loggar försvinner annars vid omstart |
 | `npm audit --omit=dev` passerar | Inga kända sårbarheter i produktionsberoenden |
 
 ### Säkerhetskontroll före deploy

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -154,4 +154,9 @@ app.listen(PORT, () => {
 	} else {
 		console.log("Swagger: avstängt (SWAGGER_ENABLED != true)")
 	}
+	if (config.rateLimit.enabled) {
+		console.log("Rate limiting: aktiverat")
+	} else {
+		console.warn("Rate limiting: AVSTÄNGT (RATE_LIMIT_ENABLED=false)")
+	}
 })

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -19,10 +19,13 @@ import { createOpenApiSpec } from "./swagger.js"
 
 const app = express()
 
-// Nödvändigt när appen körs bakom reverse proxy (Railway, nginx m.fl.)
-// Utan detta ser rate limitern proxy-IP:t, inte klientens riktiga IP —
-// alla användare delar då samma rate limit-bucket.
-app.set("trust proxy", 1)
+// Aktivera trust proxy bara i produktion — appen körs då bakom en reverse proxy
+// (Railway, nginx m.fl.) som sätter X-Forwarded-For med klientens riktiga IP.
+// I dev/CI finns ingen proxy: utan detta villkor kan en klient sätta X-Forwarded-For
+// till valfri IP och kringgå IP-baserad rate limiting.
+if (config.isProduction()) {
+	app.set("trust proxy", 1)
+}
 
 const openApiSpec = createOpenApiSpec()
 

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -19,6 +19,11 @@ import { createOpenApiSpec } from "./swagger.js"
 
 const app = express()
 
+// Nödvändigt när appen körs bakom reverse proxy (Railway, nginx m.fl.)
+// Utan detta ser rate limitern proxy-IP:t, inte klientens riktiga IP —
+// alla användare delar då samma rate limit-bucket.
+app.set("trust proxy", 1)
+
 const openApiSpec = createOpenApiSpec()
 
 initDatabase()

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -1,5 +1,5 @@
 import bcrypt from "bcryptjs"
-import { type NextFunction, type Request, type Response, Router } from "express"
+import { type Response, Router } from "express"
 import rateLimit, { ipKeyGenerator } from "express-rate-limit"
 import jwt from "jsonwebtoken"
 import { v4 as uuidv4 } from "uuid"
@@ -7,6 +7,7 @@ import config from "../config.js"
 import db from "../db/database.js"
 import logger from "../logger.js"
 import type { AuthRequest } from "../middleware/auth.js"
+import { createLimiter, noopMiddleware } from "../utils/rate-limiters.js"
 import {
 	getEmailError,
 	getNameError,
@@ -32,26 +33,14 @@ const uuid = uuidv4()
 // ----------------------------------
 // Kan stängas av via RATE_LIMIT_ENABLED=false (t.ex. vid testkörning i CI)
 // I produktion ska detta ALLTID vara aktiverat.
-const noopMiddleware = (_req: Request, _res: Response, next: NextFunction) =>
-	next()
-
-const createRateLimiter = (max: number, message: string) =>
-	config.rateLimit.enabled
-		? rateLimit({
-				windowMs: 15 * 60 * 1000,
-				max,
-				message: { message },
-				standardHeaders: true,
-				legacyHeaders: false,
-			})
-		: noopMiddleware
-
-const loginLimiterByIp = createRateLimiter(
+const loginLimiterByIp = createLimiter(
 	10,
+	15 * 60 * 1000,
 	"För många inloggningsförsök. Försök igen om 15 minuter."
 )
-const registerLimiter = createRateLimiter(
+const registerLimiter = createLimiter(
 	5,
+	15 * 60 * 1000,
 	"För många registreringsförsök. Försök igen om 15 minuter."
 )
 

--- a/api/src/routes/events.ts
+++ b/api/src/routes/events.ts
@@ -371,6 +371,8 @@ router.get("/filter/search", (req: AuthRequest, res: Response) => {
  *         description: Bad request - Missing required fields or invalid data
  *       401:
  *         description: Unauthorized - Invalid or missing token
+ *       429:
+ *         description: Too many requests - Rate limit exceeded
  *       500:
  *         description: Internal server error
  */
@@ -555,6 +557,8 @@ router.post("/", createEventLimiter, (req: AuthRequest, res: Response) => {
  *         description: Forbidden - Only event creator can update
  *       404:
  *         description: Event not found
+ *       429:
+ *         description: Too many requests - Rate limit exceeded
  *       500:
  *         description: Internal server error
  */
@@ -737,6 +741,8 @@ router.put("/:id", updateEventLimiter, (req: AuthRequest, res: Response) => {
  *         description: Forbidden - Only event creator can delete
  *       404:
  *         description: Event not found
+ *       429:
+ *         description: Too many requests - Rate limit exceeded
  *       500:
  *         description: Internal server error
  */
@@ -954,6 +960,8 @@ router.get("/:id/chat", (req: AuthRequest, res: Response) => {
  *         description: Unauthorized - Invalid or missing token
  *       404:
  *         description: Event not found
+ *       429:
+ *         description: Too many requests - Rate limit exceeded
  *       500:
  *         description: Internal server error
  */

--- a/api/src/routes/events.ts
+++ b/api/src/routes/events.ts
@@ -4,7 +4,28 @@ const MAX_CHAT_MESSAGE_LENGTH = 3000
 import { type Response, Router } from "express"
 import db from "../db/database.js"
 import type { AuthRequest } from "../middleware/auth.js"
+import { createLimiter } from "../utils/rate-limiters.js"
 
+const chatLimiter = createLimiter(
+	60,
+	60 * 1000,
+	"För många meddelanden. Vänta en stund."
+)
+const createEventLimiter = createLimiter(
+	10,
+	15 * 60 * 1000,
+	"För många events skapade. Försök igen om 15 minuter."
+)
+const updateEventLimiter = createLimiter(
+	20,
+	15 * 60 * 1000,
+	"För många ändringar. Försök igen om 15 minuter."
+)
+const deleteEventLimiter = createLimiter(
+	10,
+	15 * 60 * 1000,
+	"För många borttagningar. Försök igen om 15 minuter."
+)
 const router = Router()
 
 // Typ för Event från databasen
@@ -354,7 +375,7 @@ router.get("/filter/search", (req: AuthRequest, res: Response) => {
  *         description: Internal server error
  */
 // POST /api/events - skapa nytt event
-router.post("/", (req: AuthRequest, res: Response) => {
+router.post("/", createEventLimiter, (req: AuthRequest, res: Response) => {
 	const {
 		title,
 		description,
@@ -538,7 +559,7 @@ router.post("/", (req: AuthRequest, res: Response) => {
  *         description: Internal server error
  */
 // PUT /api/events/:id - uppdatera event
-router.put("/:id", (req: AuthRequest, res: Response) => {
+router.put("/:id", updateEventLimiter, (req: AuthRequest, res: Response) => {
 	const { id } = req.params
 	const {
 		title,
@@ -720,7 +741,7 @@ router.put("/:id", (req: AuthRequest, res: Response) => {
  *         description: Internal server error
  */
 // DELETE /api/events/:id - ta bort event
-router.delete("/:id", (req: AuthRequest, res: Response) => {
+router.delete("/:id", deleteEventLimiter, (req: AuthRequest, res: Response) => {
 	const { id } = req.params
 
 	if (!id) {
@@ -936,7 +957,7 @@ router.get("/:id/chat", (req: AuthRequest, res: Response) => {
  *       500:
  *         description: Internal server error
  */
-router.post("/:id/chat", (req: AuthRequest, res: Response) => {
+router.post("/:id/chat", chatLimiter, (req: AuthRequest, res: Response) => {
 	const { id } = req.params
 	const { message } = req.body
 

--- a/api/src/routes/registrations.ts
+++ b/api/src/routes/registrations.ts
@@ -84,6 +84,8 @@ const isValidUuid = (id: string): boolean =>
  *         description: Event not found
  *       409:
  *         description: Already registered
+ *       429:
+ *         description: Too many requests - Rate limit exceeded
  */
 router.post(
 	"/:eventId/register",
@@ -224,6 +226,8 @@ router.post(
  *         description: Not authenticated
  *       404:
  *         description: Event not found or not registered
+ *       429:
+ *         description: Too many requests - Rate limit exceeded
  */
 router.delete(
 	"/:eventId/register",

--- a/api/src/routes/registrations.ts
+++ b/api/src/routes/registrations.ts
@@ -4,6 +4,18 @@
 import { type Response, Router } from "express"
 import db from "../db/database.js"
 import type { AuthRequest } from "../middleware/auth.js"
+import { createLimiter } from "../utils/rate-limiters.js"
+
+const registerLimiter = createLimiter(
+	20,
+	15 * 60 * 1000,
+	"För många registreringar. Försök igen om 15 minuter."
+)
+const unregisterLimiter = createLimiter(
+	20,
+	15 * 60 * 1000,
+	"För många avanmälningar. Försök igen om 15 minuter."
+)
 
 const router = Router()
 
@@ -73,80 +85,61 @@ const isValidUuid = (id: string): boolean =>
  *       409:
  *         description: Already registered
  */
-router.post("/:eventId/register", (req: AuthRequest, res: Response) => {
-	const { eventId } = req.params as { eventId: string }
-	const userId = req.user?.id
+router.post(
+	"/:eventId/register",
+	registerLimiter,
+	(req: AuthRequest, res: Response) => {
+		const { eventId } = req.params as { eventId: string }
+		const userId = req.user?.id
 
-	if (!userId) {
-		res.status(401).json({
-			success: false,
-			message: "Oauktoriserad användare.",
-		})
-		return
-	}
-
-	// Validera UUID-format innan vi frågar databasen
-	if (!isValidUuid(eventId)) {
-		res.status(400).json({
-			success: false,
-			message: "Ogiltigt event-ID format.",
-		})
-		return
-	}
-
-	try {
-		// Kontrollera att eventet existerar
-		const event = db
-			.prepare("SELECT id, end_time FROM events WHERE id = ?")
-			.get(eventId) as DbEvent | undefined
-
-		if (!event) {
-			res.status(404).json({
+		if (!userId) {
+			res.status(401).json({
 				success: false,
-				message: "Event med detta ID hittades inte.",
+				message: "Oauktoriserad användare.",
 			})
 			return
 		}
 
-		// Kontrollera att eventet inte har avslutats
-		if (new Date(event.end_time) < new Date()) {
+		// Validera UUID-format innan vi frågar databasen
+		if (!isValidUuid(eventId)) {
 			res.status(400).json({
 				success: false,
-				message: "Eventet har redan avslutats.",
+				message: "Ogiltigt event-ID format.",
 			})
 			return
 		}
 
-		// Kontrollera att användaren inte redan är registrerad
-		const existing = db
-			.prepare(
-				"SELECT id FROM event_registrations WHERE event_id = ? AND user_id = ?"
-			)
-			.get(eventId, userId)
-
-		if (existing) {
-			res.status(409).json({
-				success: false,
-				message: "Du är redan registrerad för detta event.",
-			})
-			return
-		}
-
-		// Registrera användaren
-		let result: ReturnType<ReturnType<typeof db.prepare>["run"]>
 		try {
-			result = db
-				.prepare(
-					"INSERT INTO event_registrations (event_id, user_id) VALUES (?, ?)"
-				)
-				.run(eventId, userId)
-		} catch (err) {
-			const sqliteError = err as { code?: string; message?: string }
-			const isUniqueConstraint =
-				sqliteError?.code === "SQLITE_CONSTRAINT_UNIQUE" ||
-				(sqliteError?.message ?? "").includes("UNIQUE constraint failed")
+			// Kontrollera att eventet existerar
+			const event = db
+				.prepare("SELECT id, end_time FROM events WHERE id = ?")
+				.get(eventId) as DbEvent | undefined
 
-			if (isUniqueConstraint) {
+			if (!event) {
+				res.status(404).json({
+					success: false,
+					message: "Event med detta ID hittades inte.",
+				})
+				return
+			}
+
+			// Kontrollera att eventet inte har avslutats
+			if (new Date(event.end_time) < new Date()) {
+				res.status(400).json({
+					success: false,
+					message: "Eventet har redan avslutats.",
+				})
+				return
+			}
+
+			// Kontrollera att användaren inte redan är registrerad
+			const existing = db
+				.prepare(
+					"SELECT id FROM event_registrations WHERE event_id = ? AND user_id = ?"
+				)
+				.get(eventId, userId)
+
+			if (existing) {
 				res.status(409).json({
 					success: false,
 					message: "Du är redan registrerad för detta event.",
@@ -154,33 +147,56 @@ router.post("/:eventId/register", (req: AuthRequest, res: Response) => {
 				return
 			}
 
-			throw err
-		}
-		const registration = db
-			.prepare("SELECT * FROM event_registrations WHERE id = ?")
-			.get(result.lastInsertRowid) as DbRegistration | undefined
+			// Registrera användaren
+			let result: ReturnType<ReturnType<typeof db.prepare>["run"]>
+			try {
+				result = db
+					.prepare(
+						"INSERT INTO event_registrations (event_id, user_id) VALUES (?, ?)"
+					)
+					.run(eventId, userId)
+			} catch (err) {
+				const sqliteError = err as { code?: string; message?: string }
+				const isUniqueConstraint =
+					sqliteError?.code === "SQLITE_CONSTRAINT_UNIQUE" ||
+					(sqliteError?.message ?? "").includes("UNIQUE constraint failed")
 
-		if (!registration) {
+				if (isUniqueConstraint) {
+					res.status(409).json({
+						success: false,
+						message: "Du är redan registrerad för detta event.",
+					})
+					return
+				}
+
+				throw err
+			}
+			const registration = db
+				.prepare("SELECT * FROM event_registrations WHERE id = ?")
+				.get(result.lastInsertRowid) as DbRegistration | undefined
+
+			if (!registration) {
+				res.status(500).json({
+					success: false,
+					message: "Registrering skapades men kunde inte hämtas.",
+				})
+				return
+			}
+
+			res.status(201).json({
+				success: true,
+				message: "Registrering genomförd.",
+				registration,
+			})
+		} catch (error) {
+			console.error("Fel vid registrering:", error)
 			res.status(500).json({
 				success: false,
-				message: "Registrering skapades men kunde inte hämtas.",
+				message: "Internt serverfel vid registrering.",
 			})
-			return
 		}
-
-		res.status(201).json({
-			success: true,
-			message: "Registrering genomförd.",
-			registration,
-		})
-	} catch (error) {
-		console.error("Fel vid registrering:", error)
-		res.status(500).json({
-			success: false,
-			message: "Internt serverfel vid registrering.",
-		})
 	}
-})
+)
 
 /**
  * @openapi
@@ -209,66 +225,72 @@ router.post("/:eventId/register", (req: AuthRequest, res: Response) => {
  *       404:
  *         description: Event not found or not registered
  */
-router.delete("/:eventId/register", (req: AuthRequest, res: Response) => {
-	const { eventId } = req.params as { eventId: string }
-	const userId = req.user?.id
+router.delete(
+	"/:eventId/register",
+	unregisterLimiter,
+	(req: AuthRequest, res: Response) => {
+		const { eventId } = req.params as { eventId: string }
+		const userId = req.user?.id
 
-	if (!userId) {
-		res.status(401).json({
-			success: false,
-			message: "Oauktoriserad användare.",
-		})
-		return
-	}
-
-	if (!isValidUuid(eventId)) {
-		res.status(400).json({
-			success: false,
-			message: "Ogiltigt event-ID format.",
-		})
-		return
-	}
-
-	try {
-		// Kontrollera att eventet existerar
-		const event = db.prepare("SELECT id FROM events WHERE id = ?").get(eventId)
-
-		if (!event) {
-			res.status(404).json({
+		if (!userId) {
+			res.status(401).json({
 				success: false,
-				message: "Event med detta ID hittades inte.",
+				message: "Oauktoriserad användare.",
 			})
 			return
 		}
 
-		// Ta bort registreringen
-		const result = db
-			.prepare(
-				"DELETE FROM event_registrations WHERE event_id = ? AND user_id = ?"
-			)
-			.run(eventId, userId)
-
-		// result.changes = 0 betyder att ingen rad togs bort (ej registrerad)
-		if (result.changes === 0) {
-			res.status(404).json({
+		if (!isValidUuid(eventId)) {
+			res.status(400).json({
 				success: false,
-				message: "Du är inte registrerad för detta event.",
+				message: "Ogiltigt event-ID format.",
 			})
 			return
 		}
 
-		res.json({
-			success: true,
-			message: "Avregistrering genomförd.",
-		})
-	} catch (error) {
-		console.error("Fel vid avregistrering:", error)
-		res.status(500).json({
-			success: false,
-			message: "Internt serverfel vid avregistrering.",
-		})
+		try {
+			// Kontrollera att eventet existerar
+			const event = db
+				.prepare("SELECT id FROM events WHERE id = ?")
+				.get(eventId)
+
+			if (!event) {
+				res.status(404).json({
+					success: false,
+					message: "Event med detta ID hittades inte.",
+				})
+				return
+			}
+
+			// Ta bort registreringen
+			const result = db
+				.prepare(
+					"DELETE FROM event_registrations WHERE event_id = ? AND user_id = ?"
+				)
+				.run(eventId, userId)
+
+			// result.changes = 0 betyder att ingen rad togs bort (ej registrerad)
+			if (result.changes === 0) {
+				res.status(404).json({
+					success: false,
+					message: "Du är inte registrerad för detta event.",
+				})
+				return
+			}
+
+			res.json({
+				success: true,
+				message: "Avregistrering genomförd.",
+			})
+		} catch (error) {
+			console.error("Fel vid avregistrering:", error)
+			res.status(500).json({
+				success: false,
+				message: "Internt serverfel vid avregistrering.",
+			})
+		}
 	}
-})
+)
 
 /**
  * @openapi

--- a/api/src/utils/rate-limiters.ts
+++ b/api/src/utils/rate-limiters.ts
@@ -1,0 +1,29 @@
+// Hjälpfunktioner för rate limiting
+// -----------------------------------
+// Kan stängas av via RATE_LIMIT_ENABLED=false (t.ex. vid testkörning i CI).
+// I produktion ska rate limiting ALLTID vara aktiverat.
+
+import type { NextFunction, Request, Response } from "express"
+import rateLimit from "express-rate-limit"
+import config from "../config.js"
+
+export const noopMiddleware = (
+	_req: Request,
+	_res: Response,
+	next: NextFunction
+) => next()
+
+export const createLimiter = (
+	max: number,
+	windowMs: number,
+	message: string
+) =>
+	config.rateLimit.enabled
+		? rateLimit({
+				windowMs,
+				max,
+				message: { message },
+				standardHeaders: true,
+				legacyHeaders: false,
+			})
+		: noopMiddleware


### PR DESCRIPTION
## Sammanfattning

Åtgärdar STRIDE-hot D1 (Denial of Service): inloggade användare kunde tidigare flöda write-endpoints utan begränsning. Lägger till rate limiting på alla POST/PUT/DELETE-endpoints med individuella gränser anpassade efter förväntad användningsfrekvens.

## Ändringar

### Ny funktionalitet
- Ny delad hjälpfil `api/src/utils/rate-limiters.ts` med `createLimiter` och `noopMiddleware`
- Rate limiting på 6 write-endpoints (se tabell nedan)
- Toggle: `RATE_LIMIT_ENABLED=false` inaktiverar allt (används i CI/Newman-tester)
- Startlogg visar om rate limiting är aktiverat eller inte (synligt i Docker/Railway-loggar)

| Endpoint | Max | Fönster |
|---|---|---|
| POST `/api/events` | 10 | 15 min |
| PUT `/api/events/:id` | 20 | 15 min |
| DELETE `/api/events/:id` | 10 | 15 min |
| POST `/api/events/:id/chat` | 60 | 1 min |
| POST `/api/events/:eventId/register` | 20 | 15 min |
| DELETE `/api/events/:eventId/register` | 20 | 15 min |

### Fixar från Copilot-review (runda 1 + 2)

**trust proxy (Copilot runda 1 + 2):**
- Lagt till `app.set("trust proxy", 1)` villkorligt, aktiveras bara i produktion
- Utan detta returnerar `req.ip` Railways proxy-IP och alla användare delar samma rate limit-bucket
- Villkorlig aktivering förhindrar att klienter kan fejka `X-Forwarded-For` i dev/CI

**En källa till sanning (Copilot runda 1):**
- `auth.ts` importerar nu `createLimiter` och `noopMiddleware` från den delade hjälpfilen
- Tar bort duplicerad lokal implementation i `auth.ts` så att samma toggle-logik och headers används konsekvent för alla limiters

**OpenAPI 429-dokumentation (Copilot runda 1):**
- Alla 6 nya rate-limitade endpoints dokumenterade med `429: Too many requests` i Swagger/OpenAPI-spec

### Kända begränsningar (teknisk skuld, dokumenterade)
- Rate limiting är per IP, inte per inloggad användare. En angripare med flera IP-adresser kan kringgå limiten. Per-user-ID kräver Redis för att fungera vid horisontell skalning.
- In-memory räknare nollställs vid omstart/redeploy, kort fönster utan skydd.
- `RATE_LIMIT_ENABLED=false` i produktion loggar bara en varning, kastar inte fel vid start.
- Delade NAT/WiFi-nätverk räknar alla användare i samma bucket.

## Testat lokalt

- [x] `npm run lint` - passerar
- [x] `npm run build` - passerar
- [x] Alla 8 Newman-samlingar - 0 fel, 92 requests, 207 assertions
- [x] `npm audit` - inga nya sårbarheter

Closes #95