### PR TITLE
docs(readme): move deployment notice to top

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Joinly
 
+> **Kurs 3 — Live:** API: https://api-production-4072.up.railway.app | Frontend: https://app-production-joinly.up.railway.app
+> Deploy sker via GitHub Actions → GHCR → Railway. De röda "Deployments" i sidopanelen beror på en äldre integration som ersattes i Kurs 3 — se [Wiki: Kurs 3 — Deploy](https://github.com/andrey-prokhorov/joinly/wiki/Kurs3-Deploy).
+
 **Joinly** - en app för att hitta sällskap för träning, snabbt och utan krångel.
 Här kan du enkelt hitta eller skapa aktiviteter som löpning, cykling eller motorcykelturer i närheten av dig.
 Du behöver inte gå med i grupper eller planera långt i förväg - se vad som händer idag eller imorgon och häng på.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Joinly
 
-> **Kurs 3 — Live:** API: https://api-production-4072.up.railway.app | Frontend: https://app-production-joinly.up.railway.app
-> Deploy sker via GitHub Actions → GHCR → Railway. De röda "Deployments" i sidopanelen beror på en äldre integration som ersattes i Kurs 3 — se [Wiki: Kurs 3 — Deploy](https://github.com/andrey-prokhorov/joinly/wiki/Kurs3-Deploy).
+> **Kurs 3 — Live:** Se [Deployment](#deployment-kurs-3) för live-URL:er, pipeline och förklaring till röda "Deployments" i GitHub-sidopanelen.
 
 **Joinly** - en app för att hitta sällskap för träning, snabbt och utan krångel.
 Här kan du enkelt hitta eller skapa aktiviteter som löpning, cykling eller motorcykelturer i närheten av dig.


### PR DESCRIPTION
Flyttar Kurs 3-notisen om live-URL:er och röda Deployments till överst i README så det syns direkt utan att scrolla.