### PR TITLE
docs(readme): note that registration is locked in live environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Joinly
 
 > **Kurs 3 — Live:** Se [Deployment](#deployment-kurs-3) för live-URL:er, pipeline och förklaring till röda "Deployments" i GitHub-sidopanelen.
+>
+> **Registrering är stängd** i live-miljön (kostnadsskydd på Railway). Testinloggning bifogas vid inlämningen.
 
 **Joinly** - en app för att hitta sällskap för träning, snabbt och utan krångel.
 Här kan du enkelt hitta eller skapa aktiviteter som löpning, cykling eller motorcykelturer i närheten av dig.


### PR DESCRIPTION
Lägger till notis överst i README om att registrering är stängd i live-miljön och att testinloggning bifogas vid inlämningen.